### PR TITLE
Add controller-tutor to dependabot automation file sync

### DIFF
--- a/.github/workflows/repo-file-sync.yaml
+++ b/.github/workflows/repo-file-sync.yaml
@@ -97,6 +97,7 @@ jobs:
             domdomegg/google-client-id-lookup
             domdomegg/airtable-mcp-server
             domdomegg/computer-use-mcp
+            domdomegg/controller-tutor
             domdomegg/tsup-831
             domdomegg/parallel-sort
             domdomegg/defuddle-fetch-mcp-server


### PR DESCRIPTION
## Summary
- Adds `domdomegg/controller-tutor` to the dependabot automation file sync list
- controller-tutor had a stale `auto-dependabot.yaml` using `ubuntu-20.04` (removed runner), which caused the dependabot automation job to queue for 24h then get cancelled — e.g. https://github.com/domdomegg/controller-tutor/pull/18

🤖 Generated with [Claude Code](https://claude.com/claude-code)