### PR TITLE
Add domdomegg/mcp-aggregator to file sync automation

### DIFF
--- a/.github/workflows/repo-file-sync.yaml
+++ b/.github/workflows/repo-file-sync.yaml
@@ -107,6 +107,7 @@ jobs:
             domdomegg/defuddle-fetch-mcp-server
             domdomegg/just-one-ai-webapp
             domdomegg/starling-bank-mcp
+            domdomegg/mcp-aggregator
           FILES: |
             file-sync/auto-dependabot.yaml=.github/workflows/auto-dependabot.yaml
           TOKEN: ${{ secrets.PAT }}
@@ -189,6 +190,7 @@ jobs:
             domdomegg/weekly-availabilities-summary
             domdomegg/benchmark-next-vs-nginx
             domdomegg/parallel-sort
+            domdomegg/mcp-aggregator
           FILES: |
             file-sync/node-general.yaml=.github/workflows/ci.yaml
           TOKEN: ${{ secrets.PAT }}


### PR DESCRIPTION
Adds mcp-aggregator to the Dependabot automation and Node.js general template sync lists, so it receives future updates to auto-dependabot.yaml and ci.yaml.