### PR TITLE
Add aws-shared-infra to dependabot file-sync

### DIFF
--- a/.github/workflows/repo-file-sync.yaml
+++ b/.github/workflows/repo-file-sync.yaml
@@ -95,6 +95,7 @@ jobs:
             domdomegg/weekly-availabilities-summary
             domdomegg/benchmark-next-vs-nginx
             domdomegg/homelab
+            domdomegg/aws-shared-infra
             domdomegg/optoma-ir-to-nec
             domdomegg/jimp-1325-mre
             domdomegg/typescript-webapp-template


### PR DESCRIPTION
Adds `domdomegg/aws-shared-infra` to the **Dependabot automation** file-sync list so it receives the canonical `auto-dependabot.yaml`.

Deliberately **not** added to the *Node.js general template* list — aws-shared-infra is a Pulumi IaC program with a custom deploy workflow (GitHub→AWS OIDC federation), so syncing `node-general.yaml` over its `ci.yaml` would clobber the deploy logic. (Same reason `homelab` is dependabot-only.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)